### PR TITLE
feat(tla): Add KelpieActorLifecycle.tla spec for actor lifecycle verification

### DIFF
--- a/crates/kelpie-server/src/actor/agent_actor.rs
+++ b/crates/kelpie-server/src/actor/agent_actor.rs
@@ -236,7 +236,7 @@ impl AgentActor {
             role: MessageRole::User,
             content: request.content.clone(),
             tool_call_id: None,
-            tool_call: None,
+            tool_calls: vec![],
             created_at: chrono::Utc::now(),
         };
 
@@ -335,7 +335,7 @@ impl AgentActor {
                 role: MessageRole::Assistant,
                 content: response.content.clone(),
                 tool_call_id: None,
-                tool_call: None,
+                tool_calls: vec![],
                 created_at: chrono::Utc::now(),
             };
             ctx.state.add_message(assistant_msg);
@@ -352,11 +352,11 @@ impl AgentActor {
                     role: MessageRole::Assistant,
                     content: response.content.clone(),
                     tool_call_id: None,
-                    tool_call: Some(ToolCall {
+                    tool_calls: vec![ToolCall {
                         id: tool_call.id.clone(),
                         name: tool_call.name.clone(),
                         arguments: tool_call.input.clone(),
-                    }),
+                    }],
                     created_at: chrono::Utc::now(),
                 };
                 ctx.state.add_message(tool_call_msg);
@@ -379,7 +379,7 @@ impl AgentActor {
                     role: MessageRole::Tool,
                     content: result,
                     tool_call_id: Some(tool_call.id.clone()),
-                    tool_call: None,
+                    tool_calls: vec![],
                     created_at: chrono::Utc::now(),
                 };
                 ctx.state.add_message(tool_msg);
@@ -473,7 +473,7 @@ impl AgentActor {
             role: MessageRole::Assistant,
             content: final_content,
             tool_call_id: None,
-            tool_call: None,
+            tool_calls: vec![],
             created_at: chrono::Utc::now(),
         };
         ctx.state.add_message(assistant_msg);

--- a/crates/kelpie-server/src/api/import_export.rs
+++ b/crates/kelpie-server/src/api/import_export.rs
@@ -118,6 +118,8 @@ pub async fn import_agent<R: Runtime + 'static>(
         tags: agent_data.tags,
         metadata: agent_data.metadata,
         project_id: agent_data.project_id,
+        user_id: None,
+        org_id: None,
     };
 
     // Create agent
@@ -172,7 +174,7 @@ fn import_messages<R: Runtime + 'static>(
             role: msg_data.role,
             content: msg_data.content,
             tool_call_id: msg_data.tool_call_id,
-            tool_call: msg_data.tool_call,
+            tool_calls: msg_data.tool_calls,
             created_at: Utc::now(),
         };
 

--- a/crates/kelpie-server/src/service/mod.rs
+++ b/crates/kelpie-server/src/service/mod.rs
@@ -447,8 +447,8 @@ impl<R: kelpie_core::Runtime> AgentService<R> {
                 }));
             }
 
-            // Add tool call if present (Letta uses singular tool_call, not plural)
-            if let Some(tool_call) = message.tool_call {
+            // Add tool calls if present
+            for tool_call in message.tool_calls {
                 chunks.push(Ok(StreamChunk::ToolCallStart {
                     id: tool_call.id,
                     name: tool_call.name,

--- a/crates/kelpie-server/src/state.rs
+++ b/crates/kelpie-server/src/state.rs
@@ -845,6 +845,8 @@ impl<R: kelpie_core::Runtime + 'static> AppState<R> {
                     tags: metadata.tags,
                     metadata: metadata.metadata,
                     project_id: None, // TODO: Add project_id to AgentMetadata
+                    user_id: None,    // TODO: Add user_id to AgentMetadata
+                    org_id: None,     // TODO: Add org_id to AgentMetadata
                     created_at: metadata.created_at,
                     updated_at: metadata.updated_at,
                 });
@@ -975,6 +977,8 @@ impl<R: kelpie_core::Runtime + 'static> AppState<R> {
             system: metadata.system,
             description: metadata.description,
             project_id: None, // Phase 6: Projects not stored in legacy storage yet
+            user_id: None,    // TODO: Store user_id in AgentMetadata
+            org_id: None,     // TODO: Store org_id in AgentMetadata
             blocks,
             tool_ids: metadata.tool_ids,
             tags: metadata.tags,
@@ -3390,6 +3394,8 @@ mod tests {
             system: None,
             description: None,
             project_id: None,
+            user_id: None,
+            org_id: None,
             memory_blocks: vec![CreateBlockRequest {
                 label: "persona".to_string(),
                 value: "I am a test agent".to_string(),

--- a/crates/kelpie-server/src/storage/adapter.rs
+++ b/crates/kelpie-server/src/storage/adapter.rs
@@ -1389,7 +1389,7 @@ mod tests {
             message_type: "user_message".to_string(),
             role: MessageRole::User,
             content: "Hello".to_string(),
-            tool_call: None,
+            tool_calls: vec![],
             tool_call_id: None,
             created_at: chrono::Utc::now(),
         };
@@ -1401,7 +1401,7 @@ mod tests {
             message_type: "assistant_message".to_string(),
             role: MessageRole::Assistant,
             content: "Hi there!".to_string(),
-            tool_call: None,
+            tool_calls: vec![],
             tool_call_id: None,
             created_at: chrono::Utc::now(),
         };
@@ -1524,7 +1524,7 @@ mod tests {
             message_type: "user_message".to_string(),
             role: MessageRole::User,
             content: "Test message".to_string(),
-            tool_call: None,
+            tool_calls: vec![],
             tool_call_id: None,
             created_at: chrono::Utc::now(),
         };

--- a/docs/tla/README.md
+++ b/docs/tla/README.md
@@ -23,9 +23,46 @@ Models the lease-based actor ownership protocol from ADR-004, verifying:
 - **G2.2 (Atomic Lease Operations)**: Lease acquisition/renewal via atomic CAS
 - **G4.2 (Single Activation)**: At most one node holds a valid lease per actor
 
+#### State Variables
+- `leases`: Ground truth - actual lease holder and expiry per actor
+- `clock`: Global wall clock time
+- `nodeBeliefs`: What each node believes it owns (can diverge from ground truth in buggy version)
+
+#### Actions
+| Action | Description | Precondition |
+|--------|-------------|--------------|
+| `AcquireLeaseSafe` | Atomic CAS lease acquisition | No valid lease exists |
+| `AcquireLeaseNoCheck` | Buggy: claim without checking | Node doesn't already believe it has lease |
+| `RenewLeaseSafe` | Extend lease duration | Current holder only |
+| `TickClock` | Advance time, expire stale beliefs | clock < MaxClock |
+| `ReleaseLease` | Voluntary deactivation | Node holds lease |
+
+#### Safety Invariants
+| Invariant | Description | ADR Reference |
+|-----------|-------------|---------------|
+| `TypeOK` | Type constraints on all variables | - |
+| `LeaseUniqueness` | At most one node believes it holds a valid lease | ADR-004 G4.2 |
+| `RenewalRequiresOwnership` | Only lease holder can renew | ADR-002 G2.2 |
+| `LeaseValidityBounds` | Lease expiry within configured bounds | - |
+| `BeliefConsistency` | Node beliefs match ground truth (safe only) | - |
+
+#### Liveness Properties
+| Property | Description |
+|----------|-------------|
+| `EventualLeaseResolution` | Eventually a lease is granted or expires |
+
 #### TLC Results
-- **Safe version**: PASS (679 distinct states)
-- **Buggy version**: FAIL - LeaseUniqueness violated
+- **Safe version**: PASS (679 distinct states, 3171 generated, depth 9)
+- **Buggy version**: FAIL - LeaseUniqueness violated in 5 states
+
+#### Counterexample (Buggy Version)
+```
+State 1: Initial - no leases
+State 2: n1 acquires lease (holder=n1, n1 believes it has it)
+State 3: n2 acquires WITHOUT CHECK (holder=n2, but BOTH n1 and n2 believe they have it!)
+```
+
+This demonstrates why FDB's atomic transactions are essential - without CAS semantics, race conditions allow dual activation.
 
 ---
 
@@ -35,9 +72,65 @@ Models the lifecycle of a Kelpie virtual actor, verifying:
 - **G1.3 (Lifecycle Ordering)**: No invoke without activate, no deactivate during invoke
 - **G1.5 (Idle Timeout)**: Actors deactivate after idle timeout
 
+#### State Variables
+- `state`: Actor lifecycle state (`Inactive`, `Activating`, `Active`, `Deactivating`)
+- `pending`: Number of pending invocations (0..MAX_PENDING)
+- `idleTicks`: Ticks since last activity (for idle timeout tracking)
+
+#### Actions
+| Action | Description | Precondition |
+|--------|-------------|--------------|
+| `Activate` | Start activation | state = Inactive |
+| `CompleteActivation` | Finish activation | state = Activating |
+| `StartInvoke` | Begin invocation | state = Active (safe) or any state (buggy) |
+| `CompleteInvoke` | Finish invocation | pending > 0 |
+| `IdleTick` | Advance idle timer | state = Active, pending = 0 |
+| `StartDeactivate` | Begin deactivation | state = Active, pending = 0, idleTicks >= IDLE_TIMEOUT |
+| `CompleteDeactivate` | Finish deactivation | state = Deactivating |
+
+#### Safety Invariants
+| Invariant | Description | ADR Reference |
+|-----------|-------------|---------------|
+| `TypeOK` | Type constraints on all variables | - |
+| `LifecycleOrdering` | Invocations only when Active | ADR-001 G1.3 |
+| `GracefulDeactivation` | No pending invocations when deactivating | ADR-001 G1.3 |
+| `IdleTimeoutRespected` | Deactivation only after timeout | ADR-001 G1.5 |
+
+#### Liveness Properties
+| Property | Description |
+|----------|-------------|
+| `EventualActivation` | Activation always completes |
+| `EventualDeactivation` | Idle actors eventually deactivate (not checked - busy actors shouldn't deactivate) |
+| `EventualInvocationCompletion` | Invocations eventually complete (not checked - model allows infinite invocations) |
+
 #### TLC Results
-- **Safe version**: PASS (11 distinct states)
+- **Safe version**: PASS (19 states generated, 11 distinct states, depth 8)
 - **Buggy version**: FAIL - LifecycleOrdering violated
+
+#### Counterexample (Buggy Version)
+```
+State 1: /\ pending = 0 /\ state = "Inactive" /\ idleTicks = 0
+State 2: /\ pending = 1 /\ state = "Inactive" /\ idleTicks = 0
+```
+
+#### Configuration Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `MAX_PENDING` | 2 | Maximum concurrent invocations |
+| `IDLE_TIMEOUT` | 3 | Ticks before idle deactivation |
+| `BUGGY` | FALSE | Enable buggy behavior for testing |
+
+#### Mapping to Rust Implementation
+
+| TLA+ Concept | Rust Implementation |
+|--------------|---------------------|
+| `state` variable | `ActivationState` enum in `activation.rs` |
+| `pending` variable | `pending_counts` in `dispatcher.rs` |
+| `idleTicks` | `idle_time()` from `ActivationStats` |
+| `StartInvoke` | `DispatcherHandle::invoke()` |
+| `process_invocation` assertion | `assert!(self.state == ActivationState::Active)` |
+| `should_deactivate()` | Check in `should_deactivate()` method |
 
 ---
 
@@ -104,4 +197,5 @@ java -XX:+UseParallelGC -jar ~/tla2tools.jar -deadlock -config KelpieMigration_B
 - [ADR-002: FoundationDB Integration](../adr/002-foundationdb-integration.md)
 - [ADR-004: Linearizability Guarantees](../adr/004-linearizability-guarantees.md)
 - [TLA+ Home](https://lamport.azurewebsites.net/tla/tla.html)
+- [TLC Model Checker](https://lamport.azurewebsites.net/tla/tools.html)
 - [Learn TLA+](https://learntla.com/)


### PR DESCRIPTION
## Summary

- Add TLA+ specification for Kelpie virtual actor lifecycle management
- Verify ADR-001 guarantees G1.3 (lifecycle ordering) and G1.5 (idle timeout)
- Include Safe and Buggy configuration variants for model checking

## TLA+ Specification Details

**State Variables:**
- `state`: Actor lifecycle state (Inactive, Activating, Active, Deactivating)
- `pending`: Number of pending invocations (0..MAX_PENDING)
- `idleTicks`: Ticks since last activity for idle timeout tracking

**Safety Invariants:**
- `TypeOK`: Type constraints on all variables
- `LifecycleOrdering`: Invocations only when Active (ADR-001 G1.3)
- `GracefulDeactivation`: No pending invocations when deactivating (ADR-001 G1.3)
- `IdleTimeoutRespected`: Deactivation only after timeout (ADR-001 G1.5)

**Liveness Property:**
- `EventualActivation`: Activation always completes

## Model Checking Results

**Safe Configuration (BUGGY=FALSE):**
```
Model checking completed. No error has been found.
19 states generated, 11 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 8.
```

**Buggy Configuration (BUGGY=TRUE):**
```
Error: Invariant LifecycleOrdering is violated.
State 1: /\ pending = 0 /\ state = "Inactive" /\ idleTicks = 0
State 2: /\ pending = 1 /\ state = "Inactive" /\ idleTicks = 0
```

## Additional Fixes

Fixed pre-existing compilation errors in library code:
- Changed `tool_call: Option<ToolCall>` usages to `tool_calls: Vec<ToolCall>`
- Added missing `user_id` and `org_id` fields to struct initializers

## Test plan

- [x] Run TLC model checker on Safe config - passes all invariants
- [x] Run TLC model checker on Buggy config - fails LifecycleOrdering as expected
- [x] Verify `cargo build` compiles successfully
- [x] Review docs/tla/README.md for documentation completeness

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)