### PR TITLE
feat(dst): Add CI enforcement for non-deterministic patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
 
+  determinism-check:
+    name: DST Pattern Enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Make script executable
+        run: chmod +x scripts/check-determinism.sh
+      - name: Check for non-deterministic patterns
+        run: ./scripts/check-determinism.sh --warn-only
+        # Note: Using --warn-only until existing violations are fixed.
+        # Change to --strict to block PRs with new violations.
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.progress/035_20260124_ci-enforcement-determinism.md
+++ b/.progress/035_20260124_ci-enforcement-determinism.md
@@ -1,0 +1,102 @@
+# Plan: CI Enforcement for Determinism (Issue #23)
+
+## Summary
+
+Add `scripts/check-determinism.sh` and CI workflow to block non-deterministic I/O patterns like `tokio::time::sleep`, `rand::random`, etc. from being used directly in DST-sensitive code.
+
+## Status: COMPLETE
+
+## Options & Decisions
+
+### Option 1: Simple grep-based CI check (Chosen)
+- **Pros:** Quick to implement, catches obvious violations, easy to understand
+- **Cons:** Can have false positives (comments, string literals)
+- **Why chosen:** Issue explicitly requests this as immediate solution
+
+### Option 2: Custom Clippy lints
+- **Pros:** Better DX, IDE integration, fewer false positives
+- **Cons:** More complex, requires separate crate, longer to implement
+- **Why not chosen:** Marked as "long-term" in issue; out of scope
+
+### Option 3: Wrapper crate approach
+- **Pros:** Compile-time enforcement via imports
+- **Cons:** Requires significant refactoring
+- **Why not chosen:** Marked as "medium-term" in issue; out of scope
+
+## Exception Strategy
+
+**Allowed exceptions (legitimate uses):**
+1. `kelpie-core/src/io.rs` - Production TimeProvider/RngProvider implementations
+2. `kelpie-core/src/runtime.rs` - Production runtime with real time
+3. `kelpie-dst/` - DST framework (seed generation, RealTime provider for comparison)
+4. `kelpie-sandbox/` - Real VM interactions need real time
+5. `kelpie-vm/` - VM backend implementations
+6. `kelpie-tools/` - CLI tools run in production
+7. `kelpie-cli/` - CLI tools run in production
+8. `kelpie-cluster/` - Cluster heartbeats/gossip
+9. Test files (`*_test.rs`, `tests/*.rs`, `#[cfg(test)]` blocks)
+
+## Phases
+
+### Phase 1: Create check-determinism.sh script [COMPLETE]
+- Created script with forbidden patterns list
+- Added exception handling for legitimate uses
+- Added `--warn-only` and `--strict` modes
+- Added `#[cfg(test)]` block detection
+- Tested locally against codebase
+
+### Phase 2: Add CI workflow job [COMPLETE]
+- Added `determinism-check` job to `.github/workflows/ci.yml`
+- Using `--warn-only` mode initially (to allow PR to merge)
+- Can switch to `--strict` once existing violations are fixed
+
+### Phase 3: Update CLAUDE.md documentation [COMPLETE]
+- Added "I/O Abstraction Requirements" section to DST documentation
+- Documented forbidden patterns and alternatives
+- Documented exception locations
+- Documented how to run the check locally
+
+### Phase 4: Create PR [COMPLETE]
+- Committed changes
+- Pushed to branch
+- Created PR
+
+## Quick Decision Log
+
+| Time | Decision | Rationale | Trade-off |
+|------|----------|-----------|-----------|
+| T+0 | Use grep-based approach | Issue explicitly requests CI script first | May have false positives |
+| T+0 | Allow kelpie-core/io.rs exception | Production implementations must use real time | Need careful review |
+| T+0 | Allow all test files | Tests may need real timing for benchmarks | Could hide violations |
+| T+1 | Add `--warn-only` mode | Allow incremental adoption | Not blocking initially |
+| T+1 | Add `#[cfg(test)]` detection | Filter out test code in src/ files | Heuristic, not perfect |
+| T+1 | Add kelpie-cluster/ exception | Cluster uses real time for heartbeats | Legitimate use case |
+
+## What to Try
+
+### Works Now
+1. Run `./scripts/check-determinism.sh` - Shows all violations
+2. Run `./scripts/check-determinism.sh --warn-only` - Reports but doesn't fail
+3. Run `./scripts/check-determinism.sh --help` - Shows usage
+
+### Known Violations (26 total)
+These are existing violations in the codebase that should be addressed:
+- `kelpie-server/http.rs` - Network delay injection (2)
+- `kelpie-registry/` - Node discovery (5)
+- `kelpie-runtime/` - Activation tracking (5)
+- `kelpie-server/state.rs` - Request tracking (8)
+- `kelpie-server/tools/` - Various tools (4)
+- `kelpie-server/service/` - Teleport service (1)
+- `kelpie-server/actor/` - Registry actor (2)
+
+### Known Limitations
+- Grep-based detection can have false positives in comments/strings
+- `#[cfg(test)]` detection is heuristic (looks for marker in prior 100 lines)
+- Exception list requires maintenance as codebase evolves
+- Currently using `--warn-only` in CI; switch to `--strict` once violations fixed
+
+## Files Changed
+
+1. `scripts/check-determinism.sh` - New script (enforcement check)
+2. `.github/workflows/ci.yml` - Added determinism-check job
+3. `CLAUDE.md` - Added I/O Abstraction Requirements documentation

--- a/scripts/check-determinism.sh
+++ b/scripts/check-determinism.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# DST Determinism Enforcement Script
+#
+# This script scans Kelpie source code for direct usage of non-deterministic
+# I/O operations that should instead use injected providers (TimeProvider, RngProvider).
+#
+# Usage:
+#   ./scripts/check-determinism.sh [OPTIONS]
+#
+# Options:
+#   --strict       Exit with code 1 on violations (default)
+#   --warn-only    Report violations but exit with code 0
+#   --help         Show this help message
+#
+# Exit codes:
+#   0 - No violations found (or --warn-only mode)
+#   1 - Violations found (--strict mode only)
+#
+# See: https://github.com/rita-aga/kelpie/issues/23
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+STRICT_MODE=true
+for arg in "$@"; do
+    case $arg in
+        --warn-only)
+            STRICT_MODE=false
+            ;;
+        --strict)
+            STRICT_MODE=true
+            ;;
+        --help|-h)
+            sed -n '2,18p' "$0" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+    esac
+done
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Change to project root
+cd "$PROJECT_ROOT"
+
+echo "=== DST Determinism Check ==="
+if [ "$STRICT_MODE" = false ]; then
+    echo -e "${YELLOW}Mode: warn-only (violations won't fail CI)${NC}"
+fi
+echo ""
+
+# Forbidden patterns that bypass DST
+# These must use TimeProvider or RngProvider instead
+FORBIDDEN_PATTERNS=(
+    "tokio::time::sleep"
+    "std::thread::sleep"
+    "rand::random"
+    "thread_rng"
+    "SystemTime::now"
+    "Instant::now"
+)
+
+# Files/paths that are ALLOWED to use these patterns
+# These are production implementations or external integrations
+EXCEPTION_PATTERNS=(
+    # Production time/rng provider implementations (exact files)
+    "kelpie-core/src/io.rs"
+    "kelpie-core/src/runtime.rs"
+    # DST framework itself (needs real time for comparison, seed generation)
+    "kelpie-dst/"
+    # VM backends interact with real VMs
+    "kelpie-vm/"
+    "kelpie-sandbox/"
+    # CLI tools run in production, not DST
+    "kelpie-cli/"
+    "kelpie-tools/"
+    # Cluster coordination uses real time for heartbeats/gossip
+    "kelpie-cluster/"
+)
+
+# Check if a file matches any exception pattern
+is_exception() {
+    local file="$1"
+
+    # Normalize path (remove double slashes)
+    file=$(echo "$file" | sed 's|//|/|g')
+
+    for pattern in "${EXCEPTION_PATTERNS[@]}"; do
+        if [[ "$file" == *"$pattern"* ]]; then
+            return 0
+        fi
+    done
+
+    # Allow test files
+    if [[ "$file" == *"_test.rs" ]] || [[ "$file" == *"/tests/"* ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Check if a line is a comment or documentation
+is_comment_or_doc() {
+    local line="$1"
+    # Check if line is primarily a comment (starts with // or //! or /// or /* after whitespace)
+    if echo "$line" | grep -qE '^\s*(//|/\*|\*|#\[)'; then
+        return 0
+    fi
+    return 1
+}
+
+# Check if line is inside a #[cfg(test)] block by looking at surrounding context
+# Note: This is a heuristic - we check if there's a #[cfg(test)] before this line
+is_in_test_module() {
+    local file="$1"
+    local line_num="$2"
+
+    # Check if there's a #[cfg(test)] before this line (within last 100 lines)
+    # This is a simple heuristic that works for most Rust code
+    local test_marker_count
+    test_marker_count=$(head -n "$line_num" "$file" 2>/dev/null | tail -n 100 | grep -c '#\[cfg(test)\]' 2>/dev/null || true)
+
+    # Handle empty output
+    if [ -z "$test_marker_count" ]; then
+        test_marker_count=0
+    fi
+
+    # Check if count > 0
+    if [ "$test_marker_count" -gt 0 ] 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+violations_found=0
+violation_count=0
+
+echo "Scanning for non-deterministic patterns..."
+echo ""
+
+for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+    echo -n "Checking: $pattern ... "
+
+    # Find all matches in src/ directories only
+    matches=$(grep -rn "$pattern" crates/*/src/ --include="*.rs" 2>/dev/null || true)
+
+    if [ -z "$matches" ]; then
+        echo -e "${GREEN}OK${NC}"
+        continue
+    fi
+
+    # Filter out exceptions and comments
+    pattern_violations=""
+    while IFS= read -r match; do
+        if [ -z "$match" ]; then
+            continue
+        fi
+
+        file=$(echo "$match" | cut -d: -f1)
+        line_num=$(echo "$match" | cut -d: -f2)
+        line_content=$(echo "$match" | cut -d: -f3-)
+
+        # Skip if file is an exception
+        if is_exception "$file"; then
+            continue
+        fi
+
+        # Skip if line is a comment/doc
+        if is_comment_or_doc "$line_content"; then
+            continue
+        fi
+
+        # Skip if inside #[cfg(test)] block
+        if is_in_test_module "$file" "$line_num"; then
+            continue
+        fi
+
+        pattern_violations="$pattern_violations$match"$'\n'
+        ((violation_count++)) || true
+    done <<< "$matches"
+
+    if [ -z "$(echo "$pattern_violations" | tr -d '[:space:]')" ]; then
+        echo -e "${GREEN}OK${NC}"
+    else
+        echo -e "${RED}VIOLATION${NC}"
+        violations_found=1
+        echo "$pattern_violations" | while IFS= read -r line; do
+            if [ -n "$line" ]; then
+                echo -e "  ${YELLOW}→${NC} $line"
+            fi
+        done
+    fi
+done
+
+echo ""
+echo "=== Summary ==="
+
+if [ $violations_found -eq 0 ]; then
+    echo -e "${GREEN}✓ No violations found${NC}"
+    echo ""
+    echo "All time/random operations use injected providers (TimeProvider, RngProvider)."
+    exit 0
+else
+    echo -e "${RED}✗ Found $violation_count violation(s)${NC}"
+    echo ""
+    echo "These patterns bypass DST determinism. Use injected providers instead:"
+    echo ""
+    echo -e "  ${BLUE}Instead of:                     Use:${NC}"
+    echo "  ─────────────────────────────────────────────────────"
+    echo "  tokio::time::sleep(dur)    →    time_provider.sleep_ms(ms)"
+    echo "  std::thread::sleep(dur)    →    time_provider.sleep_ms(ms)"
+    echo "  SystemTime::now()          →    time_provider.now_ms()"
+    echo "  Instant::now()             →    time_provider.monotonic_ms()"
+    echo "  rand::random()             →    rng_provider.next_u64()"
+    echo "  thread_rng()               →    rng_provider"
+    echo ""
+    echo -e "${BLUE}Allowed exceptions (production code):${NC}"
+    for exception in "${EXCEPTION_PATTERNS[@]}"; do
+        echo "  - $exception"
+    done
+    echo "  - Test files (*_test.rs, tests/*.rs, #[cfg(test)] blocks)"
+    echo ""
+    echo "See: crates/kelpie-core/src/io.rs for TimeProvider/RngProvider traits"
+
+    if [ "$STRICT_MODE" = true ]; then
+        exit 1
+    else
+        echo ""
+        echo -e "${YELLOW}Note: Running in --warn-only mode, not failing CI${NC}"
+        exit 0
+    fi
+fi


### PR DESCRIPTION
## Summary

Implements #23: Add compile-time enforcement to prevent non-deterministic I/O patterns from breaking DST.

- Add `scripts/check-determinism.sh` that scans for forbidden patterns (`tokio::time::sleep`, `rand::random`, `SystemTime::now`, `Instant::now`, etc.)
- Add CI workflow job `determinism-check` that runs the script on every PR
- Document I/O abstraction requirements in CLAUDE.md

## Changes

### New: `scripts/check-determinism.sh`

```bash
# Check for violations (strict mode - fails on violations)
./scripts/check-determinism.sh

# Warn-only mode (reports violations but doesn't fail)
./scripts/check-determinism.sh --warn-only
```

**Forbidden patterns:**
| Pattern | Use Instead |
|---------|-------------|
| `tokio::time::sleep(dur)` | `time_provider.sleep_ms(ms)` |
| `std::thread::sleep(dur)` | `time_provider.sleep_ms(ms)` |
| `SystemTime::now()` | `time_provider.now_ms()` |
| `Instant::now()` | `time_provider.monotonic_ms()` |
| `rand::random()` | `rng_provider.next_u64()` |
| `thread_rng()` | `rng_provider` |

**Allowed exceptions:**
- `kelpie-core/src/io.rs` - Production TimeProvider/RngProvider implementations
- `kelpie-dst/` - DST framework itself
- `kelpie-vm/`, `kelpie-sandbox/` - Real VM interactions
- `kelpie-cli/`, `kelpie-tools/` - Production CLI tools
- `kelpie-cluster/` - Cluster heartbeats/gossip
- Test files (`*_test.rs`, `tests/*.rs`, `#[cfg(test)]` blocks)

### CI Workflow

Added `determinism-check` job that runs `--warn-only` initially. Once existing violations are addressed, can switch to `--strict` mode to block PRs with new violations.

### Known Violations (26 total)

The script identifies existing violations in the codebase:
- `kelpie-registry/` - Node discovery timestamps and random selection
- `kelpie-runtime/` - Activation tracking timestamps
- `kelpie-server/` - Various timestamp usages

These should be addressed in follow-up PRs by using `TimeProvider`/`RngProvider`.

## Test plan

- [x] Run `./scripts/check-determinism.sh --help` - shows usage
- [x] Run `./scripts/check-determinism.sh` - shows violations and exits 1
- [x] Run `./scripts/check-determinism.sh --warn-only` - shows violations and exits 0
- [x] Verify CI workflow runs the check

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)