### PR TITLE
fix(dst): Clean up DST test framework (Issue #34)

### DIFF
--- a/.progress/042_20260124_github_issue_34_dst_cleanup.md
+++ b/.progress/042_20260124_github_issue_34_dst_cleanup.md
@@ -1,0 +1,157 @@
+# GitHub Issue #34: DST Cleanup
+
+**Created:** 2026-01-24
+**Status:** IN_PROGRESS
+**Issue:** https://github.com/kelpie-project/kelpie/issues/34
+
+## Summary
+
+Clean up garbage code, false claims, and bugs in the DST test framework.
+
+## Options & Decisions
+
+### liveness_dst.rs `#![allow(dead_code)]` directive
+
+**Options:**
+1. Remove directive and delete unused methods - cleanest, but may lose spec-alignment
+2. Remove directive and add `#[allow(dead_code)]` to specific unused methods with justification
+3. Exercise the unused methods in tests
+
+**Decision:** Option 2 - Keep methods that align with TLA+ specs but mark them individually with comments explaining they exist for spec completeness.
+
+**Rationale:** The methods exist to model TLA+ state machines. Deleting them would lose the spec alignment.
+
+### TOCTOU race in fault.rs
+
+**Options:**
+1. Use `compare_exchange` loop - standard atomic pattern
+2. Use `fetch_update` - cleaner Rust API
+3. Add mutex protection - simpler but heavier
+
+**Decision:** Option 1 - `compare_exchange` loop is the idiomatic atomic pattern.
+
+### Silent test failures in teleport_service_dst.rs
+
+**Options:**
+1. Add explicit assertions for Err cases
+2. Convert to Result-returning tests that surface errors
+3. Keep current pattern but add logging
+
+**Decision:** Option 1 - Add assertions. The test should fail loudly if verification fails.
+
+### Fragile error checking in agent_integration_dst.rs
+
+**Options:**
+1. Use `matches!` with error variants
+2. Add error kind enum and check against it
+3. Keep string checking but document why
+
+**Decision:** Option 1 - Use `matches!` macro for type-safe error checking.
+
+## Quick Decision Log
+
+| Time | Decision | Rationale | Trade-off |
+|------|----------|-----------|-----------|
+| 17:30 | Keep spec-aligned dead code with annotations | TLA+ model fidelity | Minor code bloat |
+| 17:31 | compare_exchange for TOCTOU fix | Standard atomic pattern | Slightly more code |
+| 17:32 | Assertions over silent failures | Fail loudly | None |
+| 17:33 | matches! over string checking | Type safety | None |
+
+## Tasks
+
+### Phase 1: Fix TOCTOU race in fault.rs (HIGH) ✅
+- [x] Fix TOCTOU race with compare_exchange loop
+
+### Phase 2: Fix liveness_dst.rs dead code (HIGH) ✅
+- [x] Remove `#![allow(dead_code)]` module-level attribute
+- [x] Add targeted `#[allow(dead_code)]` with comments for spec-aligned methods
+- [x] Annotated: `Failed` variant in WalEntryStatus, `release()`, `renew_lease()`, `release_lease()`, `complete()`, `fail()` methods
+- [x] Annotated: `clock` fields in ActivationProtocol, RegistrySystem, WalSystem
+
+### Phase 3: Fix silent test failures (MEDIUM) ✅
+- [x] Add assertion in teleport_service_dst.rs for verify_result Err case
+- [x] Changed from `if let Ok(...)` to `match` with explicit panic on unexpected Err
+
+### Phase 4: Add fault occurrence verification (MEDIUM) ✅
+- [x] Added fault stats verification in bug_hunting_dst.rs test_rapid_state_transitions
+- [x] Added fault stats verification in bug_hunting_dst.rs test_stress_many_sandboxes_high_faults
+
+### Phase 5: Fix fragile error checking (LOW) ✅
+- [x] Updated agent_integration_dst.rs to use `matches!` macro instead of string checking
+- [x] Now checks for `Error::OperationTimedOut` or `Error::Internal` types
+
+### Phase 6: Fix/remove ignored tests (LOW) ✅
+- [x] Reviewed stress_test_teleport_operations() - no block_on issue
+- [x] Fixed block_on usage in test_dst_teleport_interrupted_midway - converted to proper async/await
+
+### Phase 7: Verification ✅
+- [x] Run cargo test -p kelpie-dst - All tests pass
+- [x] Run cargo clippy -p kelpie-dst - No warnings
+- [x] Commit and push
+
+## What to Try
+
+### Works Now
+- All DST tests pass with fault injection
+- Clippy reports no warnings
+- TOCTOU race in fault injection is fixed
+- Unused TLA+ spec methods are properly documented
+
+### Doesn't Work Yet
+- N/A - All fixes complete
+
+### Known Limitations
+- Some TLA+ spec methods are kept but annotated as dead code for spec completeness
+
+## Implementation Notes
+
+### TOCTOU Fix
+Changed from check-then-act pattern to compare_exchange loop:
+```rust
+// Before (TOCTOU race):
+let trigger_count = fault_state.trigger_count.load(...);
+if trigger_count >= max { continue; }
+fault_state.trigger_count.fetch_add(1, ...);
+
+// After (atomic):
+loop {
+    let current = fault_state.trigger_count.load(...);
+    if current >= max { break; }
+    match fault_state.trigger_count.compare_exchange(current, current + 1, ...) {
+        Ok(_) => return Some(fault_type.clone()),
+        Err(_) => continue,
+    }
+}
+```
+
+### Dead Code Annotations
+Methods kept for TLA+ spec alignment:
+- `ActivationProtocol::release()` - TLA+ Release action
+- `LeaseSystem::renew_lease()` - TLA+ RenewLease action
+- `LeaseSystem::release_lease()` - TLA+ ReleaseLease action
+- `WalSystem::complete()` - TLA+ CompleteEntry action
+- `WalSystem::fail()` - TLA+ FailEntry action
+- `WalEntryStatus::Failed` - TLA+ spec state
+
+### Silent Failure Fix
+Changed from silently ignoring errors to explicit handling:
+```rust
+// Before:
+if let Ok(output) = verify_result { ... }
+
+// After:
+match verify_result {
+    Ok(output) => { assert!(...); }
+    Err(e) => { panic!("Unexpected failure: {}", e); }
+}
+```
+
+### Type-Safe Error Checking
+Changed from string matching to type matching:
+```rust
+// Before:
+assert!(err_str.contains("timed out") || err_str.contains("Internal"))
+
+// After:
+assert!(matches!(e, Error::OperationTimedOut { .. } | Error::Internal { .. }))
+```

--- a/crates/kelpie-dst/tests/agent_integration_dst.rs
+++ b/crates/kelpie-dst/tests/agent_integration_dst.rs
@@ -75,11 +75,12 @@ async fn test_agent_env_with_llm_faults() {
                 {
                     Ok(_) => success_count += 1,
                     Err(e) => {
-                        // Verify fault injection is working (LLM errors map to Internal)
-                        let err_str = e.to_string();
+                        // Verify fault injection is working (LLM errors map to Internal or OperationTimedOut)
+                        // Use matches! for type-safe error checking instead of string matching
+                        use kelpie_core::Error;
                         assert!(
-                            err_str.contains("timed out") || err_str.contains("Internal"),
-                            "Unexpected error: {}",
+                            matches!(e, Error::OperationTimedOut { .. } | Error::Internal { .. }),
+                            "Unexpected error type: {:?}",
                             e
                         );
                         failure_count += 1;

--- a/crates/kelpie-dst/tests/liveness_dst.rs
+++ b/crates/kelpie-dst/tests/liveness_dst.rs
@@ -3,8 +3,8 @@
 //! TigerStyle: Deterministic verification of temporal properties.
 //!
 //! Note: Some methods in the state machines are defined for completeness
-//! (matching TLA+ specs) but not used in all tests.
-#![allow(dead_code)]
+//! (matching TLA+ specs) but not used in all tests. These are marked with
+//! `#[allow(dead_code)]` individually with comments explaining their purpose.
 //!
 //! This module tests liveness properties defined in TLA+ specifications:
 //! - EventualActivation (KelpieSingleActivation.tla)
@@ -94,6 +94,8 @@ impl std::fmt::Display for NodeStatus {
 enum WalEntryStatus {
     Pending,
     Completed,
+    /// TLA+ spec models Failed state; kept for spec completeness
+    #[allow(dead_code)]
     Failed,
 }
 
@@ -119,7 +121,8 @@ struct ActivationProtocol {
     holder: RwLock<Option<usize>>,
     /// FDB version for OCC
     version: AtomicU64,
-    /// Clock for timeouts
+    /// Clock for timeouts (TLA+ spec includes timing; kept for spec completeness)
+    #[allow(dead_code)]
     clock: Arc<SimClock>,
 }
 
@@ -175,6 +178,8 @@ impl ActivationProtocol {
     }
 
     /// Release - active node releases
+    /// TLA+ spec includes Release action; kept for spec completeness
+    #[allow(dead_code)]
     fn release(&self, node: usize) {
         let mut states = self.node_states.write().unwrap();
         let mut holder = self.holder.write().unwrap();
@@ -233,7 +238,8 @@ struct RegistrySystem {
     placement: RwLock<Vec<Option<usize>>>,
     /// Max heartbeats before failure
     max_heartbeat_miss: u64,
-    /// Clock
+    /// Clock (TLA+ spec includes timing; kept for spec completeness)
+    #[allow(dead_code)]
     clock: Arc<SimClock>,
 }
 
@@ -438,6 +444,8 @@ impl LeaseSystem {
     }
 
     /// Renew lease
+    /// TLA+ spec includes RenewLease action; kept for spec completeness
+    #[allow(dead_code)]
     fn renew_lease(&self, node: usize, actor: usize) -> bool {
         let current_time = self.clock.now_ms();
         let holders = self.lease_holders.read().unwrap();
@@ -455,6 +463,8 @@ impl LeaseSystem {
     }
 
     /// Release lease
+    /// TLA+ spec includes ReleaseLease action; kept for spec completeness
+    #[allow(dead_code)]
     fn release_lease(&self, node: usize, actor: usize) {
         let mut holders = self.lease_holders.write().unwrap();
         let mut expiry = self.lease_expiry.write().unwrap();
@@ -536,7 +546,8 @@ struct WalSystem {
     crashed: RwLock<bool>,
     /// Whether system is recovering
     recovering: RwLock<bool>,
-    /// Clock
+    /// Clock (TLA+ spec includes timing; kept for spec completeness)
+    #[allow(dead_code)]
     clock: Arc<SimClock>,
 }
 
@@ -566,6 +577,8 @@ impl WalSystem {
     }
 
     /// Complete an entry
+    /// TLA+ spec includes CompleteEntry action; kept for spec completeness
+    #[allow(dead_code)]
     fn complete(&self, idx: usize) {
         let crashed = self.crashed.read().unwrap();
         if *crashed {
@@ -579,6 +592,8 @@ impl WalSystem {
     }
 
     /// Fail an entry
+    /// TLA+ spec includes FailEntry action; kept for spec completeness
+    #[allow(dead_code)]
     fn fail(&self, idx: usize) {
         let crashed = self.crashed.read().unwrap();
         if *crashed {


### PR DESCRIPTION
## Summary

Addresses Issue #34: DST: Cleanup garbage (liveness_dst.rs, dead code, TOCTOU race)

### Changes

1. **TOCTOU race fix in fault.rs (HIGH)**
   - Fixed race condition in `FaultInjector::should_inject()` between checking and incrementing trigger_count
   - Now uses `compare_exchange` loop for atomic check-and-update

2. **liveness_dst.rs dead code cleanup (HIGH)**
   - Removed blanket `#![allow(dead_code)]` directive
   - Added targeted `#[allow(dead_code)]` annotations with comments for TLA+ spec-aligned methods
   - Methods kept for spec completeness: `release()`, `renew_lease()`, `release_lease()`, `complete()`, `fail()`
   - Struct fields kept for spec completeness: `clock` in ActivationProtocol, RegistrySystem, WalSystem

3. **Silent test failures fixed (MEDIUM)**
   - teleport_service_dst.rs: Changed `if let Ok(...)` to explicit `match` with panic on unexpected Err
   - Tests now fail loudly instead of silently swallowing errors

4. **Fault occurrence verification (MEDIUM)**
   - bug_hunting_dst.rs: Added assertions that faults actually triggered
   - Uses `fault_injector.stats()` to verify `trigger_count > 0`

5. **Fragile error checking fixed (LOW)**
   - agent_integration_dst.rs: Replaced string checking with `matches!` macro
   - Now checks `Error::OperationTimedOut { .. } | Error::Internal { .. }` instead of string contains

6. **block_on usage fixed (LOW)**
   - teleport_service_dst.rs: Removed `futures::executor::block_on` inside async function
   - Converted to proper async/await pattern to avoid deadlocks and maintain determinism

## Test plan

- [x] `cargo test -p kelpie-dst` - All tests pass
- [x] `cargo clippy -p kelpie-dst --tests` - No warnings
- [x] Pre-commit hooks pass (fmt, clippy, tests)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)