### PR TITLE
feat(mcp): Production hardening - reconnection, graceful shutdown, health checks (Issue #55)

### DIFF
--- a/.progress/045_20260124_issue_55_mcp_client_hardening.md
+++ b/.progress/045_20260124_issue_55_mcp_client_hardening.md
@@ -1,0 +1,78 @@
+# Issue #55: MCP Client Production Hardening
+
+**Date:** 2026-01-24
+**Branch:** issue-55-mcp-hardening
+**Status:** Complete
+
+## Summary
+
+Production hardening for the MCP client (`crates/kelpie-tools/src/mcp.rs`). Adding:
+- SSE transport graceful shutdown
+- Automatic reconnection with exponential backoff
+- Health checks
+- Pagination support
+- Robust response parsing
+
+## Implementation Plan
+
+### Phase 1: SSE Transport Graceful Shutdown ✅
+**Priority:** High
+
+- [x] Fix `SseTransport::close()` to actually signal listener to stop
+- [x] Add proper shutdown handling in SSE listener task
+- [x] Store listener task handle for join-with-timeout
+- [x] Add test: `test_sse_transport_graceful_shutdown`
+
+### Phase 2: Automatic Reconnection ✅
+**Priority:** High
+
+- [x] Add `ReconnectConfig` struct with backoff settings
+- [x] Add `McpClient::reconnect()` with exponential backoff
+- [x] Add `with_reconnect_config()` builder method
+- [x] Update registry's `execute_mcp()` to use reconnect
+- [x] Add test: `test_reconnection_with_backoff`
+- [x] Add test: `test_reconnection_max_attempts_exceeded`
+
+### Phase 3: Health Checks ✅
+**Priority:** Medium
+
+- [x] Add `McpClient::health_check()` method
+- [x] Add optional `start_health_monitor()` for background monitoring
+- [x] Add test: `test_health_check`
+
+### Phase 4: Pagination Support ✅
+**Priority:** Medium
+
+- [x] Modify `discover_tools()` to handle `next_cursor`
+- [x] Handle servers that don't support pagination
+- [x] Add test: `test_tool_discovery_pagination`
+
+### Phase 5: Robust Response Parsing ✅
+**Priority:** Medium
+
+- [x] Add `extract_tool_output()` helper function
+- [x] Handle all MCP content types (text, image, resource)
+- [x] Handle empty responses meaningfully
+- [x] Add test: `test_response_parsing_edge_cases`
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/kelpie-tools/src/mcp.rs` | All phases |
+| `crates/kelpie-tools/src/lib.rs` | Export new types |
+| `crates/kelpie-server/src/tools/registry.rs` | Phase 2 integration |
+
+## Verification
+
+- [x] `cargo test -p kelpie-tools` passes (67 tests)
+- [x] `cargo clippy -p kelpie-tools -p kelpie-server` has no warnings
+- [x] `cargo fmt` applied
+
+## Quick Decision Log
+
+| Time | Decision | Rationale | Trade-off |
+|------|----------|-----------|-----------|
+| 19:35 | Use JoinHandle + abort for SSE shutdown | Clean task termination | Need to store handle |
+| 19:35 | Default 5 reconnect attempts | Balance reliability vs latency | May delay failure detection |
+| 19:35 | Use tools/list for health check | MCP has no ping method | Slightly heavier than ping |

--- a/crates/kelpie-tools/src/lib.rs
+++ b/crates/kelpie-tools/src/lib.rs
@@ -36,7 +36,11 @@ mod traits;
 
 pub use builtin::{FilesystemTool, GitTool, ShellTool};
 pub use error::{ToolError, ToolResult};
-pub use mcp::{McpClient, McpConfig, McpTool, McpToolDefinition};
+pub use mcp::{
+    extract_tool_output, McpClient, McpConfig, McpTool, McpToolDefinition, ReconnectConfig,
+    MCP_HEALTH_CHECK_INTERVAL_MS, MCP_RECONNECT_ATTEMPTS_MAX, MCP_RECONNECT_BACKOFF_MULTIPLIER,
+    MCP_RECONNECT_DELAY_MS_INITIAL, MCP_RECONNECT_DELAY_MS_MAX, MCP_SSE_SHUTDOWN_TIMEOUT_MS,
+};
 pub use registry::ToolRegistry;
 #[cfg(feature = "dst")]
 pub use sim::{


### PR DESCRIPTION
## Summary

Implements MCP client production hardening for `crates/kelpie-tools/src/mcp.rs`:

- **SSE transport graceful shutdown** with proper signal handling and timeout
- **Automatic reconnection** with exponential backoff via `ReconnectConfig`
- **Health check support** via `McpClient::health_check()`
- **Pagination support** for `tools/list` with `next_cursor` handling
- **Robust response parsing** via `extract_tool_output()` helper
- **Registry auto-reconnection** when MCP server disconnects

### New Constants (TigerStyle)

| Constant | Value | Description |
|----------|-------|-------------|
| `MCP_RECONNECT_ATTEMPTS_MAX` | 5 | Max reconnection attempts |
| `MCP_RECONNECT_DELAY_MS_INITIAL` | 100 | Initial backoff delay |
| `MCP_RECONNECT_DELAY_MS_MAX` | 30,000 | Maximum backoff delay |
| `MCP_RECONNECT_BACKOFF_MULTIPLIER` | 2.0 | Exponential backoff multiplier |
| `MCP_HEALTH_CHECK_INTERVAL_MS` | 30,000 | Default health check interval |
| `MCP_SSE_SHUTDOWN_TIMEOUT_MS` | 5,000 | SSE shutdown timeout |

### New Types Exported

- `ReconnectConfig` - Configuration for automatic reconnection
- `extract_tool_output()` - Robust MCP response content extraction

### Files Modified

| File | Changes |
|------|---------|
| `crates/kelpie-tools/src/mcp.rs` | All phases |
| `crates/kelpie-tools/src/lib.rs` | Export new types |
| `crates/kelpie-server/src/tools/registry.rs` | Auto-reconnection integration |

## Test plan

- [x] `cargo test -p kelpie-tools` passes (67 tests)
- [x] `cargo clippy -p kelpie-tools -p kelpie-server` has no warnings
- [x] `cargo fmt` applied
- [x] New tests added for all phases:
  - Reconnection config validation
  - Response parsing edge cases
  - Health check behavior

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)