### PR TITLE
fix(ci): Make FoundationDB an optional feature to fix CI

### DIFF
--- a/crates/kelpie-server/Cargo.toml
+++ b/crates/kelpie-server/Cargo.toml
@@ -9,7 +9,9 @@ repository.workspace = true
 authors.workspace = true
 
 [features]
-default = ["fdb"]
+# Note: FDB is NOT default because it requires FoundationDB client libraries at compile time.
+# Enable explicitly with --features fdb when FDB is installed.
+default = []
 otel = ["kelpie-core/otel", "prometheus"]
 dst = ["kelpie-tools/dst", "dep:kelpie-dst"]
 fdb = ["dep:foundationdb", "kelpie-storage/fdb"]

--- a/crates/kelpie-server/src/storage/mod.rs
+++ b/crates/kelpie-server/src/storage/mod.rs
@@ -19,12 +19,14 @@
 //! 3. **DST-first** - All operations can have faults injected
 
 mod adapter;
+#[cfg(feature = "fdb")]
 mod fdb;
 mod teleport;
 mod traits;
 mod types;
 
 pub use adapter::KvAdapter;
+#[cfg(feature = "fdb")]
 pub use fdb::FdbAgentRegistry;
 pub use kelpie_core::teleport::{
     Architecture, SnapshotKind, TeleportPackage, TeleportStorage, TeleportStorageError,

--- a/crates/kelpie-storage/Cargo.toml
+++ b/crates/kelpie-storage/Cargo.toml
@@ -9,7 +9,9 @@ repository.workspace = true
 authors.workspace = true
 
 [features]
-default = ["fdb"]
+# Note: FDB is NOT default because it requires FoundationDB client libraries at compile time.
+# Enable explicitly with --features fdb when FDB is installed.
+default = []
 fdb = ["foundationdb"]
 
 [dependencies]

--- a/crates/kelpie-storage/src/lib.rs
+++ b/crates/kelpie-storage/src/lib.rs
@@ -7,17 +7,19 @@
 //! Provides durable, transactional key-value storage for each actor.
 //! Supports multiple backends:
 //! - In-memory (for testing and DST)
-//! - FoundationDB (production backend, enabled by default)
+//! - FoundationDB (production backend, requires `fdb` feature)
 //!
 //! # Features
 //!
-//! - `fdb` - FoundationDB backend (default, requires FDB C client installed)
+//! - `fdb` - FoundationDB backend (optional, requires FDB C client installed)
 
+#[cfg(feature = "fdb")]
 pub mod fdb;
 pub mod kv;
 pub mod memory;
 pub mod transaction;
 
+#[cfg(feature = "fdb")]
 pub use fdb::{FdbActorTransaction, FdbKV};
 pub use kv::{ActorKV, ActorTransaction, KVOperation, ScopedKV};
 pub use memory::MemoryKV;


### PR DESCRIPTION
## Summary
- Remove `fdb` from default features in kelpie-storage and kelpie-server
- Make fdb module declarations conditional on the `fdb` feature
- Make CLI --fdb-cluster-file arg conditional on the `fdb` feature

## Problem
The CI was failing because FoundationDB client libraries (`foundationdb-gen` requires `/usr/include/foundationdb/fdb.options`) are not installed on GitHub Actions runners, but `fdb` was the default feature for both crates.

## Solution
This allows CI to build and test without FoundationDB while still supporting FDB in production by enabling `--features fdb`.

## Test plan
- [x] `cargo check --all-targets --features otel,firecracker` - passes
- [x] `cargo clippy --all-targets --features otel,firecracker -- -D warnings` - no warnings
- [x] `cargo test --features otel,firecracker` - all tests pass
- [x] `cargo fmt --check` - passes
- [x] Verified `foundationdb` is not in dependency tree when FDB feature disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)