### PR TITLE
feat: implement OpenAI SSE streaming support

### DIFF
--- a/.progress/057_20260128_openai-sse-streaming.md
+++ b/.progress/057_20260128_openai-sse-streaming.md
@@ -67,7 +67,7 @@ Add Server-Sent Events (SSE) streaming support for OpenAI API, matching the exis
 - [x] Research complete
 - [x] Implementation
 - [x] Testing (5 unit tests added)
-- [ ] PR created
+- [x] PR created: https://github.com/rita-aga/kelpie/pull/82
 
 ## Implementation Summary
 


### PR DESCRIPTION
## Summary

Adds Server-Sent Events (SSE) streaming support for OpenAI API, achieving parity with the existing Anthropic streaming implementation.

- Add `stream_openai()` method to `LlmClient`
- Add `parse_openai_sse_stream()` function for OpenAI's SSE format
- Update `stream_complete_with_tools()` to dispatch to OpenAI provider
- Handle OpenAI-specific format: `choices[0].delta.content` and `data: [DONE]` marker

## Research Summary (RLM Analysis)

Thorough codebase investigation using RLM tools revealed:

| Aspect | Anthropic | OpenAI |
|--------|-----------|--------|
| Content delta | `{"type":"content_block_delta","delta":{"text":"..."}}` | `{"choices":[{"delta":{"content":"..."}}]}` |
| Completion | `{"type":"message_stop"}` | `{"choices":[{"finish_reason":"stop"}]}` then `data: [DONE]` |
| Auth header | `x-api-key` | `Authorization: Bearer` |
| Endpoint | `/messages` | `/chat/completions` |

## Test plan

- [x] Unit tests for OpenAI SSE parsing (4 tests added)
- [x] `cargo test -p kelpie-server llm::tests` - all 5 tests pass
- [x] `cargo clippy` - no warnings
- [x] `cargo fmt --check` - properly formatted
- [ ] Integration test with real OpenAI API (requires API key)

## Known Limitations

- Tool calling during streaming deferred to future PR (OpenAI uses different delta format for tool_calls)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)