### PR TITLE
docs: Verify KelpieRegistry.tla spec is complete

### DIFF
--- a/.progress/062_20260129_issue93-registry-tla.md
+++ b/.progress/062_20260129_issue93-registry-tla.md
@@ -1,0 +1,80 @@
+# Issue #93: Complete KelpieRegistry.tla specification
+
+**Status:** VERIFIED COMPLETE
+**Created:** 2026-01-29
+**Issue:** https://github.com/rita-aga/kelpie/issues/93
+
+---
+
+## Investigation Summary
+
+Issue #93 claims KelpieRegistry.tla is:
+1. Truncated at "Liveness Pr" (~200 lines)
+2. Missing `Next` definition
+3. Missing `Spec` definition
+4. Missing INVARIANT declarations for TLC
+
+### Findings: Issue Claims Are INCORRECT
+
+**Actual state of KelpieRegistry.tla:**
+- **241 lines** (not ~200)
+- **Complete `Next` definition** (line 180)
+- **Complete `Spec` definition** (line 239): `Spec == Init /\ [][Next]_vars /\ Fairness`
+- **Full Liveness section** (lines 211-233)
+- **Full Fairness section** (lines 228-233)
+
+**KelpieRegistry.cfg already has INVARIANT declarations:**
+```tla
+INVARIANT TypeOK
+INVARIANT SingleActivation
+INVARIANT PlacementConsistency
+PROPERTY EventualFailureDetection
+PROPERTY EventualCacheInvalidation
+```
+
+### TLC Verification
+
+Ran TLC model checker - **PASSED with no errors**:
+```
+Model checking completed. No error has been found.
+22845 states generated, 6174 distinct states found, 0 states left on queue.
+The depth of the complete state graph search is 19.
+Finished in 01s
+```
+
+---
+
+## Minor Issue Found
+
+`KelpieRegistry_Buggy.cfg` references a `BUGGY` constant that doesn't exist in `KelpieRegistry.tla`. This is a documentation/configuration mismatch but doesn't affect the main spec's completeness.
+
+---
+
+## Decision
+
+**Option A: Close issue as already resolved** ✓ SELECTED
+- The spec is complete and verified
+- Issue claims are based on an outdated state of the file
+- No code changes needed
+
+**Option B: Add BUGGY mode for consistency**
+- Add BUGGY constant and conditional logic to KelpieRegistry.tla
+- Would make buggy config work but adds unnecessary complexity
+
+---
+
+## Resolution
+
+1. ✅ Verified spec is complete
+2. ✅ Verified TLC passes
+3. Create PR with no code changes, documenting that the issue was already resolved
+4. Close issue #93
+
+---
+
+## Quick Decision Log
+
+| Time | Decision | Rationale |
+|------|----------|-----------|
+| 19:21 | Close as resolved | Investigation proves all claimed issues are already fixed |
+


### PR DESCRIPTION
## Summary

- Investigated issue #93 claims about KelpieRegistry.tla being truncated/incomplete
- **Found that all claims are incorrect** - the spec is already complete
- Verified with TLC model checker - all properties pass

## Investigation Findings

Issue #93 claimed:
- File truncated at "Liveness Pr" (~200 lines)
- Missing `Next` definition
- Missing `Spec` definition  
- Missing INVARIANT declarations

**Actual state:**
- 241 lines (complete)
- `Next` definition at line 180
- `Spec == Init /\ [][Next]_vars /\ Fairness` at line 239
- Full Liveness section (lines 211-233)
- Full Fairness section (lines 228-233)
- `KelpieRegistry.cfg` already has all INVARIANT/PROPERTY declarations

## TLC Verification

```
Model checking completed. No error has been found.
22,845 states generated, 6,174 distinct states found
Finished in 01s
```

## Test plan

- [x] Verified spec is syntactically correct (TLC parses successfully)
- [x] Verified all safety invariants pass (SingleActivation, PlacementConsistency, TypeOK)
- [x] Verified all liveness properties pass (EventualFailureDetection, EventualCacheInvalidation)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)